### PR TITLE
feat: add trigger check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: Check Event Type
+      run: |
+        if [[ "${{ github.event_name }}" != "pull_request" && "${{ github.event_name }}" != "pull_request_target" ]]; then
+          echo "This workflow was not triggered by a pull request or pull request target event."
+          exit 1
+        fi
+
     - name: Check target branch
       if: github.event.pull_request.base.ref == ''
       uses: actions/github-script@v6


### PR DESCRIPTION
Fixes #9 

🗣️ I'm creating a draft pull request to discuss this with anyone reviewing this. There are two things I'd like to discuss:

1. Do we need to specify an allow list for event triggers when this only works for pull requests? I now hardcoded a check for `pull_request` and `pull_request_target`.
2. Isn't the `Check target branch` step going to cut it? It checks if `github.event.pull_request.base.ref` is not empty, and if it is, it fails the pipeline.